### PR TITLE
docs: MkDocs Material site (auto-deploy to GitHub Pages)

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,51 @@
+name: Deploy MkDocs to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          pip install mkdocs-material
+
+      - name: Build docs/ from stub folders
+        run: python3 bin/build_docs.py
+
+      - name: Build site
+        run: mkdocs build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site/
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ data/
 *.pt
 *.pth
 *.ckpt
+docs/
+site/

--- a/bin/build_docs.py
+++ b/bin/build_docs.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""
+Build docs/ directory for MkDocs from per-stub folders.
+
+mkdocs requires docs_dir to be a child directory of the config file,
+so we can't point at the repo root directly. This script copies the
+relevant content into docs/ before mkdocs build.
+
+Usage:
+    python3 bin/build_docs.py
+
+CI runs this before `mkdocs build`. docs/ is gitignored.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+DOCS = ROOT / "docs"
+
+IGNORE = shutil.ignore_patterns(
+    "__pycache__", "*.pyc", "*.pyo",
+    ".cache", "*.npz", "*.tar.gz", "*.gz",
+)
+
+
+def is_stub_folder(p: Path) -> bool:
+    """A stub folder has README.md and at least one .py file at top level."""
+    if not p.is_dir():
+        return False
+    if p.name.startswith(".") or p.name in {"docs", "bin", "site"}:
+        return False
+    if not (p / "README.md").exists():
+        return False
+    return any(child.suffix == ".py" for child in p.iterdir())
+
+
+def main() -> None:
+    if DOCS.exists():
+        shutil.rmtree(DOCS)
+    DOCS.mkdir()
+
+    # Top-level docs
+    for name in ("README.md", "RESULTS.md"):
+        src = ROOT / name
+        if src.exists():
+            shutil.copy(src, DOCS / name)
+
+    # Per-stub folders
+    stubs = sorted(p.name for p in ROOT.iterdir() if is_stub_folder(p))
+    print(f"Found {len(stubs)} stub folders")
+    for stub in stubs:
+        src = ROOT / stub
+        dst = DOCS / stub
+        shutil.copytree(src, dst, ignore=IGNORE)
+
+    print(f"Built {DOCS} with {len(stubs) + 2} top-level entries")
+
+
+if __name__ == "__main__":
+    main()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,129 @@
+site_name: Hinton Problems
+site_description: Implementations of synthetic learning problems from Geoffrey Hinton's experimental papers (1981–2022)
+site_url: https://cybertronai.github.io/hinton-problems/
+repo_url: https://github.com/cybertronai/hinton-problems
+repo_name: cybertronai/hinton-problems
+
+docs_dir: docs
+
+theme:
+  name: material
+  palette:
+    - scheme: default
+      primary: deep purple
+      accent: amber
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      primary: deep purple
+      accent: amber
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.top
+    - search.suggest
+    - search.highlight
+    - content.code.copy
+    - toc.follow
+    - content.action.edit
+  icon:
+    repo: fontawesome/brands/github
+
+plugins:
+  - search
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.tasklist:
+      custom_checkbox: true
+  - attr_list
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+
+exclude_docs: |
+  bin/
+  .github/
+  .git/
+  *.py
+  *.gz
+  *.ipynb
+  __pycache__/
+  .cache/
+  CONTRIBUTING.md
+
+nav:
+  - Home: README.md
+  - Results: RESULTS.md
+  - 1980s — Foundations:
+    - "encoder-4-2-4 ★ (worked example)": encoder-4-2-4/README.md
+    - encoder-3-parity: encoder-3-parity/README.md
+    - encoder-4-3-4: encoder-4-3-4/README.md
+    - encoder-8-3-8: encoder-8-3-8/README.md
+    - encoder-40-10-40: encoder-40-10-40/README.md
+    - encoder-backprop-8-3-8: encoder-backprop-8-3-8/README.md
+    - xor: xor/README.md
+    - n-bit-parity: n-bit-parity/README.md
+    - symmetry: symmetry/README.md
+    - negation: negation/README.md
+    - binary-addition: binary-addition/README.md
+    - t-c-discrimination: t-c-discrimination/README.md
+    - recurrent-shift-register: recurrent-shift-register/README.md
+    - sequence-lookup-25: sequence-lookup-25/README.md
+    - distributed-to-local-bottleneck: distributed-to-local-bottleneck/README.md
+    - shifter: shifter/README.md
+    - grapheme-sememe: grapheme-sememe/README.md
+    - family-trees: family-trees/README.md
+    - riser-spectrogram: riser-spectrogram/README.md
+    - fast-weights-rehearsal: fast-weights-rehearsal/README.md
+  - 1990s — Unsupervised & Helmholtz:
+    - vowel-mixture-experts: vowel-mixture-experts/README.md
+    - random-dot-stereograms: random-dot-stereograms/README.md
+    - sunspots: sunspots/README.md
+    - spline-images-factorial-vq: spline-images-factorial-vq/README.md
+    - dipole-position: dipole-position/README.md
+    - dipole-3d-constraint: dipole-3d-constraint/README.md
+    - dipole-what-where: dipole-what-where/README.md
+    - helmholtz-shifter: helmholtz-shifter/README.md
+    - bars: bars/README.md
+  - 2000s — RBMs & deep belief:
+    - bars-rbm: bars-rbm/README.md
+    - transforming-pairs: transforming-pairs/README.md
+    - bouncing-balls-2: bouncing-balls-2/README.md
+    - bouncing-balls-3: bouncing-balls-3/README.md
+  - 2010s — Capsules, distillation, attention:
+    - transforming-autoencoders: transforming-autoencoders/README.md
+    - deep-lambertian-spheres: deep-lambertian-spheres/README.md
+    - rnn-pathological: rnn-pathological/README.md
+    - distillation-mnist-omitted-3: distillation-mnist-omitted-3/README.md
+    - air-multimnist: air-multimnist/README.md
+    - air-3d-primitives: air-3d-primitives/README.md
+    - fast-weights-associative-retrieval: fast-weights-associative-retrieval/README.md
+    - multi-level-glimpse-mnist: multi-level-glimpse-mnist/README.md
+    - catch-game: catch-game/README.md
+    - affnist: affnist/README.md
+    - multimnist-capsnet: multimnist-capsnet/README.md
+    - smallnorb-novel-viewpoint: smallnorb-novel-viewpoint/README.md
+    - constellations: constellations/README.md
+  - 2020s — Subclass, GLOM, Forward-Forward:
+    - mnist-2x5-subclass: mnist-2x5-subclass/README.md
+    - geo-flow-capsules: geo-flow-capsules/README.md
+    - ellipse-world: ellipse-world/README.md
+    - ff-hybrid-mnist: ff-hybrid-mnist/README.md
+    - ff-label-in-input: ff-label-in-input/README.md
+    - ff-recurrent-mnist: ff-recurrent-mnist/README.md
+    - ff-cifar-locally-connected: ff-cifar-locally-connected/README.md
+    - ff-aesop-sequences: ff-aesop-sequences/README.md


### PR DESCRIPTION
Sets up the docs site at `cybertronai.github.io/hinton-problems`, separate from SutroYaro's site. Material theme matches SutroYaro's deep-purple/amber palette for visual consistency across cybertronai sites.

## What's in this PR

- `mkdocs.yml` — Material theme, nav grouped by decade (1980s / 1990s / 2000s / 2010s / 2020s) with all 54 stub READMEs listed
- `bin/build_docs.py` — copies stub folders into `docs/` before mkdocs build (mkdocs requires `docs_dir` to be a child of the config file). Idempotent; `docs/` is gitignored.
- `.github/workflows/deploy-docs.yml` — builds + auto-deploys to GitHub Pages on every push to main
- `.gitignore` — adds `docs/` and `site/`

## What gets rendered

- **Home** = current README (with the v1-complete banner from PR #42)
- **Results** = RESULTS.md (per-stub metrics catalog Yaroslav asked for)
- **54 stub pages** = each stub's existing README, in-place — GIFs and viz/ PNGs render naturally
- Decade-grouped sidebar nav, full-text search, light/dark toggle

## Post-merge

Once this lands on main:
1. GH Actions builds the site, pushes to `gh-pages` branch
2. Repo settings → Pages → Source = GitHub Actions (one-time setup if not already)
3. Site live at https://cybertronai.github.io/hinton-problems/

## Local preview

```bash
pip install mkdocs-material
python3 bin/build_docs.py && python3 -m mkdocs serve
```

---
_agent-0bserver07 (Claude Code) on behalf of Yad_