### PR TITLE
v2: ByteDMD encoder pair — backprop-8-3-8 vs encoder-3-parity (RBM CD-1)

### DIFF
--- a/v2-bytedmd/README.md
+++ b/v2-bytedmd/README.md
@@ -1,0 +1,57 @@
+# v2 ByteDMD instrumentation
+
+ByteDMD cost measurements for selected algorithm pairs from the hinton-problems v1 baselines. Companion to [issue #45](https://github.com/cybertronai/hinton-problems/issues/45).
+
+ByteDMD measures data-movement cost as the sum of ceil(sqrt(reuse_distance)) over all memory reads, modelling the energy cost of fetching data through a 2D-laid-out LRU cache hierarchy. See [cybertronai/ByteDMD](https://github.com/cybertronai/ByteDMD) for the full spec.
+
+Because ByteDMD traces Python-level operations, all kernels here are pure Python (nested lists, no numpy). The stubs in the parent folders use numpy and cannot be directly wrapped.
+
+## Encoder pair — backprop vs Boltzmann
+
+`encoder_pair_comparison.py` — compares one training step of `encoder-backprop-8-3-8` (MLP + SGD) against `encoder-3-parity` (RBM + CD-1). Both architectures solve the encoder bottleneck; the question is which pays less to move weights through the memory hierarchy.
+
+### Results (single pattern, 5 random weight seeds)
+
+```
+Backprop 8-3-8  (48 weight values)
+  forward  (reads W1 once, W2 once)         :     541
+  backward (re-reads W2 once for delta_h)   :     685
+  total                                      :   1,226
+  cost/weight                                :    25.5
+  second-pass penalty (bwd/fwd)             :    1.27x
+
+Boltzmann CD-1  (12 weight values)
+  positive phase (reads W once)             :     142
+  negative phase (reads W twice more)       :     299
+  total                                      :     441
+  cost/weight                                :    36.8
+  second-pass penalty (neg/pos)             :    2.11x
+```
+
+### Finding
+
+Backprop has a **lower second-pass penalty** (1.27x vs 2.11x). This is counter to the naive "backprop refetches all activations" hypothesis and has a structural explanation:
+
+- In the backward pass, **W1 is never re-read** — `dW1 = x · delta_h` only needs `x` and `delta_h`, both recently created (shallow). Only W2 is re-read once (for `delta_h` via `delta_out · W2`), and it has been displaced by just 11 forward activations (h=3, y=8).
+- In CD-1, W is re-read **twice** in the negative phase (for v_neg and h_prob_neg), against a matrix of only 12 values. The ~8 intermediate values created during the positive phase (h_prob_pos=4, comparison results=4) represent ~67% relative displacement of W, vs ~23% for W2 in backprop (11 intermediates / 24 W2 values).
+
+The "commute" that matters is not the absolute displacement but the **relative** one: a smaller weight matrix gets pushed relatively deeper by the same volume of intermediate activations.
+
+Per-weight cost (25.5 vs 36.8) also favours backprop, though the two architectures differ in size so this is not a direct comparison.
+
+### How to run
+
+```bash
+cd v2-bytedmd
+python3 encoder_pair_comparison.py
+```
+
+No dependencies beyond the Python standard library. `bytedmd.py` is vendored from [cybertronai/ByteDMD](https://github.com/cybertronai/ByteDMD).
+
+## Next pairs (open)
+
+Per [issue #45](https://github.com/cybertronai/hinton-problems/issues/45), the recommended follow-up pairs are:
+
+- `bars` vs `bars-rbm` (wake-sleep vs CD-1 on the same data)
+- `shifter` vs `helmholtz-shifter` (Boltzmann vs Helmholtz on the same structure)
+- `encoder-4-2-4` (Boltzmann) to close the size gap between the two encoders above

--- a/v2-bytedmd/bytedmd.py
+++ b/v2-bytedmd/bytedmd.py
@@ -1,0 +1,424 @@
+"""
+ByteDMD tracer — LRU stack with eager initialization and aggressive compaction.
+
+  1. Simultaneous pricing: All inputs are priced against the pre-instruction
+     stack state before LRU bumping, guaranteeing commutativity.
+  2. Eager initialization: Arguments are loaded onto the stack left to right —
+     the first argument sits at the top (depth 1). No cold misses.
+  3. Liveness Analysis and Aggressive Compaction: Two-pass analysis strictly
+     limits stack size by immediately discarding elements when their last
+     operation completes, dynamically sliding remaining items up the stack.
+"""
+
+import math
+import operator
+
+class _Context:
+    __slots__ = ('stack', 'trace', 'sync', 'memo', 'counter', 'ir', 'events', 'last_use')
+    
+    def __init__(self):
+        self.stack, self.trace, self.sync, self.ir, self.events = [], [], [], [], []
+        self.memo = {}
+        self.counter = 0
+
+    def allocate(self, deferred=False):
+        """Allocate a tracking ID. Deferred pushing until second pass via STORE event."""
+        self.counter += 1
+        if not deferred:
+            self.events.append(('STORE', self.counter))
+        return self.counter
+
+    def read(self, keys):
+        """Emits a READ_BATCH logical event mapped to be priced during pass 2."""
+        valid = [k for k in keys if k is not None]
+        if not valid: return []
+        self.events.append(('READ_BATCH', valid))
+        return [0] * len(valid)
+
+class _Tracked:
+    __slots__ = ('_ctx', '_key', 'val')
+    def __init__(self, ctx, key, val):
+        self._ctx, self._key, self.val = ctx, key, val
+
+    def _rd(self):
+        self._ctx.read([self._key])
+        return self.val
+
+    def __str__(self): return str(self.val)
+    def __repr__(self): return f"Tracked({self.val})"
+    def __bool__(self): return bool(self._rd())
+    def __int__(self): return int(self._rd())
+    def __float__(self): return float(self._rd())
+    def __complex__(self): return complex(self._rd())
+    def __index__(self): return operator.index(self._rd())
+    def __hash__(self): return hash(self._rd())
+
+def _make_op(op, rev=False):
+    name = op.__name__
+    def method(self, *args):
+        keys = [getattr(a, '_key', None) for a in args]
+        vals = [getattr(a, 'val', a) for a in args]
+
+        read_keys = [keys[0], self._key] + keys[1:] if rev else [self._key] + keys
+        res = op(vals[0], self.val, *vals[1:]) if rev else op(self.val, *vals)
+        
+        depths = self._ctx.read(read_keys)
+        valid_keys = [k for k in read_keys if k is not None]
+
+        if res is NotImplemented:
+            self._ctx.events.append(('OP', name, valid_keys, None))
+            return res
+
+        self._ctx.events.append(('OP_START', name, valid_keys))
+        wrapped = _wrap(self._ctx, res)
+        out_key = getattr(wrapped, '_key', None)
+        
+        self._ctx.events.append(('OP_END', name, valid_keys, out_key))
+        return wrapped
+    return method
+
+_OPS = {
+    **{k: getattr(operator, k) for k in 'add sub mul truediv floordiv mod lshift rshift xor matmul neg pos abs invert eq ne lt le gt ge'.split()},
+    'and': operator.and_, 'or': operator.or_, 'divmod': divmod, 'pow': pow,
+    'trunc': math.trunc, 'ceil': math.ceil, 'floor': math.floor, 'round': round
+}
+
+for n, f in _OPS.items():
+    setattr(_Tracked, f'__{n}__', _make_op(f))
+    if n in 'add sub mul truediv floordiv mod divmod pow lshift rshift and xor or matmul'.split():
+        setattr(_Tracked, f'__r{n}__', _make_op(f, rev=True))
+
+def _wrap(ctx, val, deferred=False):
+    if isinstance(val, _Tracked): return val
+    vid = id(val)
+    if vid in ctx.memo: return ctx.memo[vid]
+
+    typ = type(val)
+    is_prim = typ in (int, float, bool, complex, str)
+    
+    if typ.__name__ == 'ndarray':
+        import numpy as np
+        res = np.empty_like(val, dtype=object)
+        if not is_prim:
+            ctx.memo[vid] = res
+            ctx.sync.append((val, res))
+        for idx in np.ndindex(val.shape):
+            v = val[idx]
+            res[idx] = _wrap(ctx, v.item() if hasattr(v, 'item') and not isinstance(v, np.ndarray) else v, deferred)
+        return res
+
+    if isinstance(val, (list, tuple)):
+        res = typ(_wrap(ctx, v, deferred) for v in val)
+        if not is_prim:
+            ctx.memo[vid] = res
+            if typ is list: ctx.sync.append((val, res))
+        return res
+
+    key = ctx.allocate(deferred)
+    res = _Tracked(ctx, key, val)
+    if not is_prim: ctx.memo[vid] = res
+    return res
+
+def _unwrap(val, memo=None):
+    if memo is None: memo = {}
+    vid = id(val)
+    if vid in memo: return memo[vid]
+
+    typ = type(val)
+    is_prim = typ in (int, float, bool, complex, str)
+    
+    if isinstance(val, (list, tuple)):
+        res = typ(_unwrap(v, memo) for v in val)
+        if not is_prim: memo[vid] = res
+        return res
+
+    if typ.__name__ == 'ndarray':
+        import numpy as np
+        if val.dtype == object:
+            flat = [_unwrap(x, memo) for x in val.flat]
+            try: res = np.array(flat).reshape(val.shape)
+            except Exception:
+                res = np.empty_like(val, dtype=object)
+                for i, x in enumerate(flat): res.flat[i] = x
+        else: res = val
+        if not is_prim: memo[vid] = res
+        return res
+
+    res = getattr(val, 'val', val)
+    if not is_prim: memo[vid] = res
+    return res
+
+def _pass2(ctx, res):
+    """Pass 2: Computes liveness over the event log, vaporizes dead variables, and constructs the trace."""
+    events = ctx.events
+    last_use = {}
+    for i, ev in enumerate(events):
+        if ev[0] == 'READ_BATCH':
+            for k in ev[1]:
+                last_use[k] = i
+        elif ev[0] == 'STORE':
+            k = ev[1]
+            if k not in last_use:
+                last_use[k] = i
+
+    names = {}
+    def collect_keys(val):
+        if isinstance(val, _Tracked):
+            names[val._key] = True
+        elif isinstance(val, (list, tuple)):
+            for v in val: collect_keys(v)
+        elif type(val).__name__ == 'ndarray':
+            import numpy as np
+            for v in val.flat: collect_keys(v)
+    collect_keys(res)
+    
+    # Results are marked alive until the end
+    for k in names:
+        last_use[k] = len(events)
+        
+    stack = []
+    trace = []
+    ir = []
+    last_depths_map = {}
+    op_start_stack = []
+    
+    def kill_dead_variables(current_idx):
+        nonlocal stack
+        new_stack = []
+        for k in stack:
+            if last_use.get(k, -1) > current_idx:
+                new_stack.append(k)
+        stack = new_stack
+
+    for i, ev in enumerate(events):
+        if ev[0] == 'STORE':
+            k = ev[1]
+            stack.append(k)
+            ir.append(('STORE', k))
+            kill_dead_variables(i)
+            
+        elif ev[0] == 'READ_BATCH':
+            valid = ev[1]
+            unique = list(dict.fromkeys(valid))
+            depths_map = {}
+            L = len(stack)
+            
+            # Price simultaneously against active universe
+            for k in unique:
+                depths_map[k] = L - stack.index(k)
+            
+            trace.extend(depths_map[k] for k in valid)
+            for k in valid:
+                ir.append(('READ', k, depths_map[k]))
+                
+            for k in unique:
+                stack.remove(k)
+                stack.append(k)
+                
+            last_depths_map = depths_map
+            kill_dead_variables(i)
+            
+        elif ev[0] == 'OP_START':
+            op_start_stack.append(len(ir))
+            
+        elif ev[0] == 'OP_END':
+            name, valid_keys, out_key = ev[1], ev[2], ev[3]
+            depths = [last_depths_map.get(k, 0) for k in valid_keys]
+            
+            idx = op_start_stack.pop()
+            ir.insert(idx, ('OP', name, valid_keys, depths, out_key))
+            
+        elif ev[0] == 'OP':
+            # Fallback for NotImplemented returns
+            name, valid_keys, out_key = ev[1], ev[2], ev[3]
+            depths = [last_depths_map.get(k, 0) for k in valid_keys]
+            ir.append(('OP', name, valid_keys, depths, out_key))
+
+    ctx.trace = trace
+    ctx.ir = ir
+    ctx.last_use = last_use
+
+def _sum_usqrt(N):
+    if N <= 0: return 0
+    M = math.isqrt(N - 1) + 1
+    return M * (6 * N - 2 * M * M + 3 * M - 1) // 6
+
+def traced_eval(func, args):
+    ctx = _Context()
+    # Wrap in reverse order so the first argument ends up at the top of the
+    # stack (pushed last).  The wrapped_args tuple is kept in original order
+    # for passing to the function.
+    rev_wrapped = [_wrap(ctx, a) for a in reversed(args)]
+    wrapped_args = tuple(reversed(rev_wrapped))
+    res = func(*wrapped_args)
+
+    _pass2(ctx, res)
+
+    memo = {}
+    for orig, wrapped in ctx.sync:
+        if isinstance(orig, list): orig[:] = _unwrap(wrapped, memo)
+        elif type(orig).__name__ == 'ndarray': orig[...] = _unwrap(wrapped, memo)
+
+    return ctx.trace, _unwrap(res, memo)
+
+def trace_to_bytedmd(trace, bytes_per_element):
+    if bytes_per_element == 1: return sum(math.isqrt(d - 1) + 1 for d in trace)
+    bpe = bytes_per_element
+    return sum(_sum_usqrt(d * bpe) - _sum_usqrt((d - 1) * bpe) for d in trace)
+
+def inspect_ir(func, args):
+    ctx = _Context()
+    rev_wrapped = [_wrap(ctx, a) for a in reversed(args)]
+    wrapped_args = tuple(reversed(rev_wrapped))
+    res = func(*wrapped_args)
+    _pass2(ctx, res)
+    return ctx.ir
+
+def format_ir(ir):
+    out, total = [], 0
+    for ev in ir:
+        if ev[0] == 'STORE':
+            out.append(f"STORE v{ev[1]}")
+        elif ev[0] == 'READ':
+            cost = math.isqrt(ev[2] - 1) + 1
+            out.append(f"  READ v{ev[1]}@{ev[2]}  cost={cost}")
+        else:
+            _, name, keys, depths, _ok = ev
+            cost = sum(math.isqrt(d - 1) + 1 for d in depths)
+            total += cost
+            rd = ", ".join(f"v{k}@{d}" for k, d in zip(keys, depths))
+            out.append(f"OP    {name}({rd})  cost={cost}")
+    out.append(f"# total cost = {total}")
+    return "\n".join(out)
+
+def _collect_keys(wrapped, name, names):
+    """Walk a wrapped structure to map tracking keys to human-readable names."""
+    if isinstance(wrapped, _Tracked):
+        names[wrapped._key] = name
+    elif isinstance(wrapped, (list, tuple)):
+        for i, v in enumerate(wrapped):
+            _collect_keys(v, f"{name}[{i}]", names)
+    elif type(wrapped).__name__ == 'ndarray':
+        import numpy as np
+        for idx in np.ndindex(wrapped.shape):
+            sub = name + ''.join(f'[{i}]' for i in idx)
+            _collect_keys(wrapped[idx], sub, names)
+
+_OP_SYMBOLS = {
+    'add': '+', 'sub': '-', 'mul': '*', 'truediv': '/', 'floordiv': '//',
+    'mod': '%', 'pow': '**', 'matmul': '@', 'lshift': '<<', 'rshift': '>>',
+    'and_': '&', 'or_': '|', 'xor': '^', 'eq': '==', 'ne': '!=',
+    'lt': '<', 'le': '<=', 'gt': '>', 'ge': '>=', 'neg': '-', 'pos': '+',
+    'abs': 'abs', 'invert': '~',
+}
+
+def trace_ir(func, args):
+    """Replay an IR step-by-step with variable names and the compacted logical stack state."""
+    import inspect
+    ctx = _Context()
+    rev_wrapped = [_wrap(ctx, a) for a in reversed(args)]
+    wrapped_args = tuple(reversed(rev_wrapped))
+    res = func(*wrapped_args)
+    
+    _pass2(ctx, res)
+    ir = ctx.ir
+    last_use = ctx.last_use
+
+    # Re-calculate a mapped local `last_use` map dict to tie directly to `ir` iteration formatting
+    last_use_ir = {}
+    for i, ev in enumerate(ir):
+        if ev[0] == 'STORE':
+            if ev[1] not in last_use_ir:
+                last_use_ir[ev[1]] = i
+        elif ev[0] == 'READ':
+            last_use_ir[ev[1]] = i
+        elif ev[0] == 'OP':
+            for k in ev[2]:
+                last_use_ir[k] = i
+
+    names = {}
+    def collect_keys_val(val):
+        if isinstance(val, _Tracked):
+            names[val._key] = True
+        elif isinstance(val, (list, tuple)):
+            for v in val: collect_keys_val(v)
+        elif type(val).__name__ == 'ndarray':
+            import numpy as np
+            for v in val.flat: collect_keys_val(v)
+    collect_keys_val(res)
+    for k in names:
+        last_use_ir[k] = len(ir)
+
+    names = {}
+    try:
+        param_names = list(inspect.signature(func).parameters.keys())
+    except (ValueError, TypeError):
+        param_names = [f'arg{i}' for i in range(len(args))]
+    for pname, warg in zip(param_names, wrapped_args):
+        _collect_keys(warg, pname, names)
+
+    def n(key):
+        return names.get(key, f'v{key}')
+
+    stack = []
+    out = []
+    total = 0
+
+    def fmt_stack():
+        return '[' + ', '.join(n(k) for k in stack) + ']'
+        
+    def compact(current_idx):
+        new_stack = []
+        for k in stack:
+            if k in last_use_ir and last_use_ir[k] <= current_idx:
+                pass # Vaporize on death
+            else:
+                new_stack.append(k)
+        stack[:] = new_stack
+
+    for i, ev in enumerate(ir):
+        tag = ev[0]
+        if tag == 'STORE':
+            key = ev[1]
+            stack.append(key)
+            compact(i)
+            out.append(f"STORE {n(key):<20}              stack={fmt_stack()}")
+        elif tag == 'READ':
+            key, depth = ev[1], ev[2]
+            cost = math.isqrt(depth - 1) + 1
+            if key not in stack:
+                stack.append(key)
+            stack.remove(key)
+            stack.append(key)
+            
+            is_last_in_read_block = True
+            if i + 1 < len(ir) and ir[i+1][0] in ('READ', 'OP'):
+                is_last_in_read_block = False
+                
+            out.append(f"  READ {n(key)}@{depth:<3} cost={cost:<3}          stack={fmt_stack()}")
+            
+            if is_last_in_read_block:
+                compact(i)
+        elif tag == 'OP':
+            _, opname, keys, depths, out_key = ev
+            total += sum(math.isqrt(d - 1) + 1 for d in depths)
+            sym = _OP_SYMBOLS.get(opname, opname)
+            if out_key is not None:
+                if len(keys) == 2:
+                    names[out_key] = f"({n(keys[0])}{sym}{n(keys[1])})"
+                elif len(keys) == 1:
+                    names[out_key] = f"{sym}({n(keys[0])})"
+                else:
+                    names[out_key] = f"{opname}({', '.join(n(k) for k in keys)})"
+            
+            # The operation natively completes read requirements, enabling stack clearance
+            compact(i)
+
+    out.append(f"# total cost = {total}")
+    result = "\n".join(out)
+    print(result)
+    return result
+
+def bytedmd(func, args, bytes_per_element=1):
+    trace, _ = traced_eval(func, args)
+    return trace_to_bytedmd(trace, bytes_per_element)

--- a/v2-bytedmd/encoder_pair_comparison.py
+++ b/v2-bytedmd/encoder_pair_comparison.py
@@ -51,14 +51,18 @@ def _sigmoid(x):
 # W1[i][j]: weight from input i (0..7) to hidden j (0..2)
 # W2[j][k]: weight from hidden j (0..2) to output k (0..7)
 
-def bp_forward_phase(W1, b1, W2, b2, x, target):
-    """Forward pass only. target is on the stack but not read — kept so that
-    the stack layout matches bp_full_step exactly for a valid decomposition."""
+def _bp_forward(W1, b1, W2, b2, x):
     h = [_sigmoid(sum(x[i] * W1[i][j] for i in range(8)) + b1[j])
          for j in range(3)]
     y = [_sigmoid(sum(h[j] * W2[j][k] for j in range(3)) + b2[k])
          for k in range(8)]
     return h, y
+
+
+def bp_forward_phase(W1, b1, W2, b2, x, target):
+    """Forward pass only. target is on the stack but not read — kept so that
+    the stack layout matches bp_full_step exactly for a valid decomposition."""
+    return _bp_forward(W1, b1, W2, b2, x)
 
 
 def bp_full_step(W1, b1, W2, b2, x, target):
@@ -72,14 +76,9 @@ def bp_full_step(W1, b1, W2, b2, x, target):
       - dW1 = x . delta_h   -- only needs x and delta_h (both shallow)
       - dW2 = h . delta_out  -- only needs h and delta_out (both shallow)
     """
-    # Forward
-    h = [_sigmoid(sum(x[i] * W1[i][j] for i in range(8)) + b1[j])
-         for j in range(3)]
-    y = [_sigmoid(sum(h[j] * W2[j][k] for j in range(3)) + b2[k])
-         for k in range(8)]
-    # Backward
+    h, y = _bp_forward(W1, b1, W2, b2, x)
     delta_out = [y[k] - target[k] for k in range(8)]
-    # W2 re-read here — it has been displaced by h (3) and y (8) = 11 new values
+    # W2 re-read here — displaced by h (3) and y (8) = 11 new values
     delta_h = [sum(delta_out[k] * W2[j][k] for k in range(8)) * h[j] * (1.0 - h[j])
                for j in range(3)]
     dW2 = [[h[j] * delta_out[k] for k in range(8)] for j in range(3)]
@@ -101,11 +100,20 @@ def _sample(probs):
     return [1.0 if _SAMPLE_RNG.random() < p else 0.0 for p in probs]
 
 
+def _rbm_h_given_v(W, b_h, v):
+    return [_sigmoid(sum(v[i] * W[i][j] for i in range(3)) + b_h[j])
+            for j in range(4)]
+
+
+def _rbm_v_given_h(W, b_v, h):
+    return [_sigmoid(sum(h[j] * W[i][j] for j in range(4)) + b_v[i])
+            for i in range(3)]
+
+
 def cd_positive_phase(W, b_v, b_h, v):
     """Positive phase only. b_v is on stack but not read — present so the
     stack layout matches cd_full_step exactly."""
-    return [_sigmoid(sum(v[i] * W[i][j] for i in range(3)) + b_h[j])
-            for j in range(4)]
+    return _rbm_h_given_v(W, b_h, v)
 
 
 def cd_full_step(W, b_v, b_h, v):
@@ -119,18 +127,11 @@ def cd_full_step(W, b_v, b_h, v):
         W further displaced by v_prob_neg (3) and v_neg (3) = 6 more values.
     Total: W read 3x. No backward pass; all reads are within the Gibbs chain.
     """
-    # Positive phase
-    h_prob_pos = [_sigmoid(sum(v[i] * W[i][j] for i in range(3)) + b_h[j])
-                  for j in range(4)]
-    h_pos = _sample(h_prob_pos)
-    # Negative phase — W displaced by h_prob_pos (4) + h_pos (4 untracked)
-    v_prob_neg = [_sigmoid(sum(h_pos[j] * W[i][j] for j in range(4)) + b_v[i])
-                  for i in range(3)]
-    v_neg = _sample(v_prob_neg)
-    # Negative h — W displaced further by v_prob_neg (3) + v_neg (3 untracked)
-    h_prob_neg = [_sigmoid(sum(v_neg[i] * W[i][j] for i in range(3)) + b_h[j])
-                  for j in range(4)]
-    # Gradients
+    h_prob_pos = _rbm_h_given_v(W, b_h, v)
+    h_pos      = _sample(h_prob_pos)
+    v_prob_neg = _rbm_v_given_h(W, b_v, h_pos)
+    v_neg      = _sample(v_prob_neg)
+    h_prob_neg = _rbm_h_given_v(W, b_h, v_neg)
     dW   = [[v[i] * h_prob_pos[j] - v_neg[i] * h_prob_neg[j]
              for j in range(4)] for i in range(3)]
     db_v = [v[i] - v_neg[i] for i in range(3)]

--- a/v2-bytedmd/encoder_pair_comparison.py
+++ b/v2-bytedmd/encoder_pair_comparison.py
@@ -1,0 +1,255 @@
+"""
+v2 ByteDMD instrumentation — encoder-3-parity vs encoder-backprop-8-3-8
+
+Measures data-movement cost (ByteDMD) of one training step per algorithm
+and compares second-pass penalty: how much more expensive does a weight
+re-read become after the first pass fills the LRU stack with activations?
+
+Backprop 8-3-8:
+  - forward: reads W1 (8x3=24 values) and W2 (3x8=24 values)
+  - backward: re-reads W2 only (for delta_h via error backprop); W1 is NOT
+    re-read — dW1 = x.T @ delta_h needs only x and delta_h, both shallow.
+  - Second-pass penalty = cost of backward / cost of forward (W2 deeper now)
+
+Boltzmann CD-1 (encoder-3-parity):
+  - positive phase: reads W (3x4=12 values)
+  - negative phase: reads W twice more (for v_neg prob and h_prob_neg)
+  - Second-pass penalty = cost of negative / cost of positive
+
+Decomposition method: measure positive/forward phase independently with the
+same argument signature as the full step, so stack depths are identical.
+The negative/backward cost is then (full_cost - phase1_cost).
+
+Architectures:
+  backprop-8-3-8   : W1 (8x3) + W2 (3x8) = 48 weight values, 11 biases
+  encoder-3-parity : W  (3x4) = 12 weight values, 7 biases (19 params total)
+
+Usage:
+    cd v2-bytedmd
+    python3 encoder_pair_comparison.py
+"""
+
+import math
+import random
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from bytedmd import bytedmd
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _sigmoid(x):
+    return 1.0 / (1.0 + math.exp(-max(-50.0, min(50.0, x))))
+
+
+# ---------------------------------------------------------------------------
+# Backprop 8-3-8
+# ---------------------------------------------------------------------------
+# W1[i][j]: weight from input i (0..7) to hidden j (0..2)
+# W2[j][k]: weight from hidden j (0..2) to output k (0..7)
+
+def bp_forward_phase(W1, b1, W2, b2, x, target):
+    """Forward pass only. target is on the stack but not read — kept so that
+    the stack layout matches bp_full_step exactly for a valid decomposition."""
+    h = [_sigmoid(sum(x[i] * W1[i][j] for i in range(8)) + b1[j])
+         for j in range(3)]
+    y = [_sigmoid(sum(h[j] * W2[j][k] for j in range(3)) + b2[k])
+         for k in range(8)]
+    return h, y
+
+
+def bp_full_step(W1, b1, W2, b2, x, target):
+    """Full forward + backward for one pattern.
+
+    Note on weight reads:
+      - W1 is read once (forward, computing h). Not re-read in backward.
+      - W2 is read twice: forward (computing y) then backward (computing
+        delta_h via error backprop). W2 is deeper on the LRU stack the
+        second time, displaced by h (3 values) and y (8 values).
+      - dW1 = x . delta_h   -- only needs x and delta_h (both shallow)
+      - dW2 = h . delta_out  -- only needs h and delta_out (both shallow)
+    """
+    # Forward
+    h = [_sigmoid(sum(x[i] * W1[i][j] for i in range(8)) + b1[j])
+         for j in range(3)]
+    y = [_sigmoid(sum(h[j] * W2[j][k] for j in range(3)) + b2[k])
+         for k in range(8)]
+    # Backward
+    delta_out = [y[k] - target[k] for k in range(8)]
+    # W2 re-read here — it has been displaced by h (3) and y (8) = 11 new values
+    delta_h = [sum(delta_out[k] * W2[j][k] for k in range(8)) * h[j] * (1.0 - h[j])
+               for j in range(3)]
+    dW2 = [[h[j] * delta_out[k] for k in range(8)] for j in range(3)]
+    dW1 = [[x[i] * delta_h[j] for j in range(3)] for i in range(8)]
+    db2 = list(delta_out)
+    db1 = list(delta_h)
+    return dW1, db1, dW2, db2
+
+
+# ---------------------------------------------------------------------------
+# Boltzmann / RBM — encoder-3-parity
+# ---------------------------------------------------------------------------
+# W[i][j]: weight from visible i (0..2) to hidden j (0..3)
+# CD-1: positive → sample h → negative v → sample v_neg → negative h → gradient
+
+_SAMPLE_RNG = random.Random(0)  # seeded per measurement
+
+def _sample(probs):
+    return [1.0 if _SAMPLE_RNG.random() < p else 0.0 for p in probs]
+
+
+def cd_positive_phase(W, b_v, b_h, v):
+    """Positive phase only. b_v is on stack but not read — present so the
+    stack layout matches cd_full_step exactly."""
+    return [_sigmoid(sum(v[i] * W[i][j] for i in range(3)) + b_h[j])
+            for j in range(4)]
+
+
+def cd_full_step(W, b_v, b_h, v):
+    """Full CD-1 step for one visible pattern.
+
+    Note on weight reads:
+      - Positive phase: W read once (computing h_prob_pos).
+      - Negative v:     W read again (computing v_prob_neg via W.T).
+        By now W is displaced by h_prob_pos (4) and h_pos (4) = 8 new values.
+      - Negative h:     W read a third time (computing h_prob_neg).
+        W further displaced by v_prob_neg (3) and v_neg (3) = 6 more values.
+    Total: W read 3x. No backward pass; all reads are within the Gibbs chain.
+    """
+    # Positive phase
+    h_prob_pos = [_sigmoid(sum(v[i] * W[i][j] for i in range(3)) + b_h[j])
+                  for j in range(4)]
+    h_pos = _sample(h_prob_pos)
+    # Negative phase — W displaced by h_prob_pos (4) + h_pos (4 untracked)
+    v_prob_neg = [_sigmoid(sum(h_pos[j] * W[i][j] for j in range(4)) + b_v[i])
+                  for i in range(3)]
+    v_neg = _sample(v_prob_neg)
+    # Negative h — W displaced further by v_prob_neg (3) + v_neg (3 untracked)
+    h_prob_neg = [_sigmoid(sum(v_neg[i] * W[i][j] for i in range(3)) + b_h[j])
+                  for j in range(4)]
+    # Gradients
+    dW   = [[v[i] * h_prob_pos[j] - v_neg[i] * h_prob_neg[j]
+             for j in range(4)] for i in range(3)]
+    db_v = [v[i] - v_neg[i] for i in range(3)]
+    db_h = [h_prob_pos[j] - h_prob_neg[j] for j in range(4)]
+    return dW, db_v, db_h
+
+
+# ---------------------------------------------------------------------------
+# Weight initializers
+# ---------------------------------------------------------------------------
+
+def _init_bp(seed=0):
+    rng = random.Random(seed)
+    W1 = [[rng.uniform(-0.1, 0.1) for _ in range(3)] for _ in range(8)]
+    b1 = [0.0] * 3
+    W2 = [[rng.uniform(-0.1, 0.1) for _ in range(8)] for _ in range(3)]
+    b2 = [0.0] * 8
+    return W1, b1, W2, b2
+
+
+def _init_rbm(seed=0):
+    rng = random.Random(seed)
+    W    = [[rng.gauss(0, 0.1) for _ in range(4)] for _ in range(3)]
+    b_v  = [0.0] * 3
+    b_h  = [0.0] * 4
+    return W, b_v, b_h
+
+
+# ---------------------------------------------------------------------------
+# Measurements
+# ---------------------------------------------------------------------------
+
+def measure_backprop(seed=0):
+    W1, b1, W2, b2 = _init_bp(seed)
+    x      = [1.0] + [0.0] * 7   # one-hot pattern 0
+    target = x[:]
+
+    fwd_cost  = bytedmd(bp_forward_phase, (W1, b1, W2, b2, x, target))
+    full_cost = bytedmd(bp_full_step,     (W1, b1, W2, b2, x, target))
+    return {
+        "forward":  fwd_cost,
+        "backward": full_cost - fwd_cost,
+        "total":    full_cost,
+        "n_weights": 48,
+    }
+
+
+def measure_boltzmann(seed=0):
+    global _SAMPLE_RNG
+    _SAMPLE_RNG = random.Random(seed + 99)
+
+    W, b_v, b_h = _init_rbm(seed)
+    v = [0.0, 1.0, 1.0]   # even-parity pattern 011
+
+    pos_cost  = bytedmd(cd_positive_phase, (W, b_v, b_h, v))
+    full_cost = bytedmd(cd_full_step,      (W, b_v, b_h, v))
+    return {
+        "positive_phase": pos_cost,
+        "negative_phase": full_cost - pos_cost,
+        "total":          full_cost,
+        "n_weights":      12,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Report
+# ---------------------------------------------------------------------------
+
+def main():
+    N_SEEDS = 5
+    bp_runs  = [measure_backprop(s)  for s in range(N_SEEDS)]
+    rbm_runs = [measure_boltzmann(s) for s in range(N_SEEDS)]
+
+    def avg(runs, key):
+        return sum(r[key] for r in runs) / len(runs)
+
+    bp  = {k: avg(bp_runs,  k) for k in bp_runs[0]}
+    rbm = {k: avg(rbm_runs, k) for k in rbm_runs[0]}
+
+    print("=" * 62)
+    print("ByteDMD encoder pair — v2 instrumentation")
+    print("  encoder-backprop-8-3-8  vs  encoder-3-parity (RBM CD-1)")
+    print(f"  averaged over {N_SEEDS} random weight seeds, single pattern")
+    print("=" * 62)
+
+    bp_ratio  = bp["backward"]  / bp["forward"]
+    rbm_ratio = rbm["negative_phase"] / rbm["positive_phase"]
+
+    print()
+    print(f"Backprop 8-3-8  ({int(bp['n_weights'])} weight values)")
+    print(f"  forward  (reads W1 once, W2 once)         : {bp['forward']:>7.0f}")
+    print(f"  backward (re-reads W2 once for delta_h)   : {bp['backward']:>7.0f}")
+    print(f"  total                                      : {bp['total']:>7.0f}")
+    print(f"  cost/weight                                : {bp['total']/bp['n_weights']:>7.1f}")
+    print(f"  second-pass penalty (bwd/fwd)              : {bp_ratio:>7.2f}x")
+
+    print()
+    print(f"Boltzmann CD-1  ({int(rbm['n_weights'])} weight values)")
+    print(f"  positive phase (reads W once)             : {rbm['positive_phase']:>7.0f}")
+    print(f"  negative phase (reads W twice more)       : {rbm['negative_phase']:>7.0f}")
+    print(f"  total                                      : {rbm['total']:>7.0f}")
+    print(f"  cost/weight                                : {rbm['total']/rbm['n_weights']:>7.1f}")
+    print(f"  second-pass penalty (neg/pos)              : {rbm_ratio:>7.2f}x")
+
+    print()
+    print("─" * 62)
+    print("Finding:")
+    if bp_ratio < rbm_ratio:
+        print(f"  Backprop has LOWER second-pass penalty ({bp_ratio:.2f}x vs {rbm_ratio:.2f}x).")
+        print(f"  W2 is re-read in backward (displaced by 11 forward activations: h=3, y=8)")
+        print(f"  but only W2 is re-read — W1 is never accessed in the backward pass.")
+        print(f"  Boltzmann CD reads its smaller W matrix three times (pos + two neg),")
+        print(f"  and each re-read finds W relatively deeper (12 weights, ~8 intermediates).")
+    else:
+        print(f"  Boltzmann has LOWER second-pass penalty ({rbm_ratio:.2f}x vs {bp_ratio:.2f}x).")
+    print()
+    print(f"  Per-weight cost: backprop {bp['total']/bp['n_weights']:.1f}  vs  boltzmann {rbm['total']/rbm['n_weights']:.1f}")
+    print(f"  (note: networks are different sizes — not a direct comparison)")
+
+
+if __name__ == "__main__":
+    main()

--- a/v2-bytedmd/total_cost_comparison.py
+++ b/v2-bytedmd/total_cost_comparison.py
@@ -1,0 +1,364 @@
+"""
+v2 ByteDMD — total cost to solve: backprop vs Boltzmann, same problem
+
+Addresses two gaps in encoder_pair_comparison.py (raised in PR #50 review):
+
+  1. Single-pattern measurement underestimates backprop's activation
+     re-fetch cost. Fixed here by measuring the full batch (all 8 patterns
+     at once), so all forward activations accumulate on the LRU stack before
+     the backward pass re-reads W2.
+
+  2. Per-step cost is not comparable across algorithms that need different
+     numbers of steps. Fixed by measuring TOTAL ByteDMD to reach convergence:
+       total_cost = steps_to_solve x bytedmd_per_step
+
+     Algorithm pair is now encoder-backprop-8-3-8 vs encoder-8-3-8 (RBM),
+     which solve the *same* problem (8 one-hot patterns through a 3-bit
+     bottleneck), making the convergence comparison valid.
+
+     Note: encoder-3-parity from the previous script solves a *different*
+     problem (3-bit parity), so that per-step comparison was not comparable
+     on convergence grounds either.
+
+Architectures (both encode the same 8-pattern set):
+  backprop-8-3-8   : W1 (8x3) + W2 (3x8) = 48 weight values
+  encoder-8-3-8    : W (16x3)             = 48 weight values  ← same count
+    16 visible = 8 input (V1) + 8 output (V2), 3 hidden
+
+Usage:
+    cd v2-bytedmd
+    python3 total_cost_comparison.py
+"""
+
+import math
+import random
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(Path(__file__).parent))   # bytedmd
+sys.path.insert(0, str(ROOT / "encoder-backprop-8-3-8"))
+sys.path.insert(0, str(ROOT / "encoder-8-3-8"))
+
+from bytedmd import bytedmd
+import encoder_backprop_8_3_8 as bp_ref
+import encoder_8_3_8 as rbm_ref
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _sigmoid(x):
+    return 1.0 / (1.0 + math.exp(-max(-50.0, min(50.0, x))))
+
+_SAMPLE_RNG = random.Random(0)
+
+def _sample(probs):
+    return [1.0 if _SAMPLE_RNG.random() < p else 0.0 for p in probs]
+
+# ---------------------------------------------------------------------------
+# Backprop 8-3-8 — full-batch kernels
+# ---------------------------------------------------------------------------
+# patterns: list of 8 lists of length 8 (one-hot)
+# W1[i][j], W2[j][k] as before
+
+def bp_fullbatch_forward(W1, b1, W2, b2, patterns):
+    """Forward pass for all 8 patterns. Activations (8*3 h + 8*8 y = 88 values)
+    accumulate on the LRU stack before backward begins."""
+    hs, ys = [], []
+    for x in patterns:
+        h = [_sigmoid(sum(x[i] * W1[i][j] for i in range(8)) + b1[j])
+             for j in range(3)]
+        y = [_sigmoid(sum(h[j] * W2[j][k] for j in range(3)) + b2[k])
+             for k in range(8)]
+        hs.append(h)
+        ys.append(y)
+    return hs, ys
+
+
+def bp_fullbatch_step(W1, b1, W2, b2, patterns):
+    """Full-batch forward + backward for all 8 patterns.
+
+    After the forward loop, all 88 activation values (h: 8x3, y: 8x8) are
+    on the LRU stack. W2 (24 values) is now displaced by 88 activations when
+    the backward pass re-reads it — much deeper than the single-pattern case.
+    """
+    # Forward — all activations land on stack
+    hs, ys = [], []
+    for x in patterns:
+        h = [_sigmoid(sum(x[i] * W1[i][j] for i in range(8)) + b1[j])
+             for j in range(3)]
+        y = [_sigmoid(sum(h[j] * W2[j][k] for j in range(3)) + b2[k])
+             for k in range(8)]
+        hs.append(h)
+        ys.append(y)
+    # Backward — W2 re-read with 88 activations above it on the stack
+    dW1 = [[0.0] * 3 for _ in range(8)]
+    dW2 = [[0.0] * 8 for _ in range(3)]
+    db1 = [0.0] * 3
+    db2 = [0.0] * 8
+    for idx, x in enumerate(patterns):
+        h, y = hs[idx], ys[idx]
+        delta_out = [y[k] - x[k] for k in range(8)]
+        delta_h = [sum(delta_out[k] * W2[j][k] for k in range(8)) * h[j] * (1.0 - h[j])
+                   for j in range(3)]
+        for i in range(8):
+            for j in range(3):
+                dW1[i][j] += x[i] * delta_h[j]
+        for j in range(3):
+            for k in range(8):
+                dW2[j][k] += h[j] * delta_out[k]
+        for j in range(3):
+            db1[j] += delta_h[j]
+        for k in range(8):
+            db2[k] += delta_out[k]
+    return dW1, db1, dW2, db2
+
+
+# ---------------------------------------------------------------------------
+# Boltzmann encoder-8-3-8 — full-batch CD kernels
+# ---------------------------------------------------------------------------
+# W[i][j]: weight from visible i (0..15) to hidden j (0..2)
+# One CD-k step on all 8 patterns.
+
+def _rbm_h_given_v_16(W, b_h, v):
+    """h_prob for one 16-bit visible pattern: sigmoid(v @ W + b_h)."""
+    return [_sigmoid(sum(v[i] * W[i][j] for i in range(16)) + b_h[j])
+            for j in range(3)]
+
+
+def _rbm_v_given_h_16(W, b_v, h):
+    """v_prob for one 3-bit hidden pattern: sigmoid(h @ W.T + b_v)."""
+    return [_sigmoid(sum(h[j] * W[i][j] for j in range(3)) + b_v[i])
+            for i in range(16)]
+
+
+def rbm_fullbatch_step(W, b_v, b_h, patterns, k=1):
+    """Full-batch CD-k on all 8 patterns.
+
+    Positive phase reads W once per pattern (8 reads total).
+    Negative phase reads W k times (v given h) + k times (h given v) per
+    pattern after being displaced by positive-phase activations.
+    Total W reads: (1 + 2k) * 8 patterns.
+    """
+    # Positive phase — W read once per pattern
+    h_probs_pos = [_rbm_h_given_v_16(W, b_h, v) for v in patterns]
+    h_samples   = [_sample(hp) for hp in h_probs_pos]
+
+    # Negative CD chain — W pushed progressively deeper each step
+    v_negs     = [v[:] for v in patterns]
+    h_negs     = list(h_samples)
+    h_probs_neg = list(h_probs_pos)
+    for _ in range(k):
+        v_prob_negs = [_rbm_v_given_h_16(W, b_v, h) for h in h_negs]
+        v_negs      = [_sample(vp) for vp in v_prob_negs]
+        h_probs_neg = [_rbm_h_given_v_16(W, b_h, v) for v in v_negs]
+        h_negs      = [_sample(hp) for hp in h_probs_neg]
+
+    # Gradients
+    n = len(patterns)
+    dW   = [[sum(patterns[b][i] * h_probs_pos[b][j] - v_negs[b][i] * h_probs_neg[b][j]
+                 for b in range(n)) / n
+             for j in range(3)] for i in range(16)]
+    db_v = [sum(patterns[b][i] - v_negs[b][i] for b in range(n)) / n
+            for i in range(16)]
+    db_h = [sum(h_probs_pos[b][j] - h_probs_neg[b][j] for b in range(n)) / n
+            for j in range(3)]
+    return dW, db_v, db_h
+
+
+def rbm_fullbatch_positive(W, b_v, b_h, patterns, k=1):
+    """Positive phase only (consistent args with full step for decomposition)."""
+    return [_rbm_h_given_v_16(W, b_h, v) for v in patterns]
+
+
+# ---------------------------------------------------------------------------
+# Weight initializers
+# ---------------------------------------------------------------------------
+
+def _init_bp(seed=0):
+    rng = random.Random(seed)
+    W1 = [[rng.uniform(-0.1, 0.1) for _ in range(3)] for _ in range(8)]
+    b1 = [0.0] * 3
+    W2 = [[rng.uniform(-0.1, 0.1) for _ in range(8)] for _ in range(3)]
+    b2 = [0.0] * 8
+    return W1, b1, W2, b2
+
+
+def _init_rbm16(seed=0):
+    rng = random.Random(seed)
+    W   = [[rng.gauss(0, 0.1) for _ in range(3)] for _ in range(16)]
+    b_v = [0.0] * 16
+    b_h = [0.0] * 3
+    return W, b_v, b_h
+
+
+# ---------------------------------------------------------------------------
+# Convergence step counts (via numpy stubs)
+# ---------------------------------------------------------------------------
+
+def count_bp_steps(n_seeds=10):
+    """Return list of epochs-to-solve for backprop, None if failed."""
+    results = []
+    for seed in range(n_seeds):
+        _, hist = bp_ref.train(n_epochs=5000, seed=seed, verbose=False)
+        solved = hist['acc'][-1] >= 1.0 and hist['n_distinct_codes'][-1] == 8
+        results.append(len(hist['epoch']) if solved else None)
+    return results
+
+
+def count_rbm_steps(n_seeds=10):
+    """Return list of (epochs, cd_updates) to first-solve for Boltzmann, None if failed.
+    Each epoch = batch_repeats=16 CD steps of 8 patterns."""
+    results = []
+    for seed in range(n_seeds):
+        _, hist = rbm_ref.train(n_epochs=4000, seed=seed, verbose=False)
+        codes = hist['n_distinct_codes']
+        first = next((i + 1 for i, c in enumerate(codes) if c == 8), None)
+        # Each epoch does batch_repeats=16 CD updates on 8 patterns
+        results.append(first * 16 if first is not None else None)
+    return results
+
+
+# ---------------------------------------------------------------------------
+# ByteDMD measurements
+# ---------------------------------------------------------------------------
+
+def measure_bp_fullbatch(n_seeds=5):
+    bp_patterns = [[1.0 if i == p else 0.0 for i in range(8)] for p in range(8)]
+    costs = []
+    for seed in range(n_seeds):
+        global _SAMPLE_RNG
+        _SAMPLE_RNG = random.Random(seed + 99)
+        W1, b1, W2, b2 = _init_bp(seed)
+        fwd  = bytedmd(bp_fullbatch_forward, (W1, b1, W2, b2, bp_patterns))
+        full = bytedmd(bp_fullbatch_step,    (W1, b1, W2, b2, bp_patterns))
+        costs.append({"forward": fwd, "backward": full - fwd, "total": full})
+    return {k: sum(c[k] for c in costs) / len(costs) for k in costs[0]}
+
+
+def measure_rbm_fullbatch(k=1, n_seeds=5):
+    # 8 patterns: each pattern has V1[i]=V2[i]=1, rest 0, length 16
+    rbm_patterns = []
+    for p in range(8):
+        v = [0.0] * 16
+        v[p] = 1.0
+        v[8 + p] = 1.0
+        rbm_patterns.append(v)
+
+    costs = []
+    for seed in range(n_seeds):
+        global _SAMPLE_RNG
+        _SAMPLE_RNG = random.Random(seed + 99)
+        W, b_v, b_h = _init_rbm16(seed)
+        pos  = bytedmd(rbm_fullbatch_positive, (W, b_v, b_h, rbm_patterns, k))
+        full = bytedmd(rbm_fullbatch_step,     (W, b_v, b_h, rbm_patterns, k))
+        costs.append({"positive": pos, "negative": full - pos, "total": full})
+    return {k_: sum(c[k_] for c in costs) / len(costs) for k_ in costs[0]}
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def median(lst):
+    s = sorted(x for x in lst if x is not None)
+    return s[len(s) // 2] if s else None
+
+
+def main():
+    print("=" * 66)
+    print("ByteDMD total cost to solve — backprop vs Boltzmann, same problem")
+    print("  encoder-backprop-8-3-8  vs  encoder-8-3-8 (RBM CD-k)")
+    print("  both encode 8 one-hot patterns through a 3-bit bottleneck")
+    print("=" * 66)
+
+    print("\n[1/3] ByteDMD per full-batch step (all 8 patterns, 5 seeds)...")
+    t0 = time.time()
+    bp_cost  = measure_bp_fullbatch()
+    rbm1_cost = measure_rbm_fullbatch(k=1)
+    rbm5_cost = measure_rbm_fullbatch(k=5)
+    print(f"      done in {time.time()-t0:.1f}s")
+
+    print("\n[2/3] Convergence step counts (10 seeds each, running numpy stubs)...")
+    t0 = time.time()
+    bp_steps  = count_bp_steps(n_seeds=10)
+    rbm_steps = count_rbm_steps(n_seeds=10)
+    print(f"      done in {time.time()-t0:.1f}s")
+
+    bp_solved  = [s for s in bp_steps  if s is not None]
+    rbm_solved = [s for s in rbm_steps if s is not None]
+
+    bp_med   = median(bp_steps)
+    rbm_med  = median(rbm_steps)
+
+    # Total ByteDMD: backprop uses 1 full-batch step per epoch
+    # Boltzmann: each "CD update" counted above is already one full-batch step
+    bp_total_med  = bp_med  * bp_cost["total"]  if bp_med  else None
+    # CD-5 is the actual training config; CD-1 shown for reference
+    rbm_total_med_cd1 = rbm_med * rbm1_cost["total"] if rbm_med else None
+    rbm_total_med_cd5 = rbm_med * rbm5_cost["total"] if rbm_med else None
+
+    print()
+    print("─" * 66)
+    print("Per full-batch step (all 8 patterns):")
+    print()
+    print(f"  Backprop 8-3-8   (W1: 8x3, W2: 3x8 = 48 weights)")
+    print(f"    forward  (W1 once, W2 once per pattern)  : {bp_cost['forward']:>9,.0f}")
+    print(f"    backward (W2 re-read, 88 activations deep): {bp_cost['backward']:>9,.0f}")
+    print(f"    total                                      : {bp_cost['total']:>9,.0f}")
+    print(f"    second-pass penalty                        : {bp_cost['backward']/bp_cost['forward']:>9.2f}x")
+    print()
+    print(f"  Boltzmann CD-1   (W: 16x3 = 48 weights)")
+    print(f"    positive phase                             : {rbm1_cost['positive']:>9,.0f}")
+    print(f"    negative phase (W read 2x more)           : {rbm1_cost['negative']:>9,.0f}")
+    print(f"    total                                      : {rbm1_cost['total']:>9,.0f}")
+    print(f"    second-pass penalty                        : {rbm1_cost['negative']/rbm1_cost['positive']:>9.2f}x")
+    print()
+    print(f"  Boltzmann CD-5   (actual training config)")
+    print(f"    positive phase                             : {rbm5_cost['positive']:>9,.0f}")
+    print(f"    negative phase (W read 10x more)          : {rbm5_cost['negative']:>9,.0f}")
+    print(f"    total                                      : {rbm5_cost['total']:>9,.0f}")
+    print(f"    second-pass penalty                        : {rbm5_cost['negative']/rbm5_cost['positive']:>9.2f}x")
+
+    print()
+    print("─" * 66)
+    print("Steps to convergence (10 seeds, 8/8 distinct codes):")
+    print()
+    print(f"  Backprop:  {len(bp_solved)}/10 solved,  "
+          f"median {bp_med} epochs  (= {bp_med} full-batch steps)")
+    print(f"  Boltzmann: {len(rbm_solved)}/10 solved,  "
+          f"median {rbm_med} CD updates  (each = 1 full-batch CD step)")
+
+    print()
+    print("─" * 66)
+    print("Total ByteDMD to solve (median steps x per-step cost):")
+    print()
+    if bp_total_med:
+        print(f"  Backprop              : {bp_total_med:>14,.0f}")
+    if rbm_total_med_cd1:
+        print(f"  Boltzmann CD-1        : {rbm_total_med_cd1:>14,.0f}  "
+              f"({rbm_total_med_cd1/bp_total_med:.1f}x backprop)")
+    if rbm_total_med_cd5:
+        print(f"  Boltzmann CD-5        : {rbm_total_med_cd5:>14,.0f}  "
+              f"({rbm_total_med_cd5/bp_total_med:.1f}x backprop)")
+
+    print()
+    print("─" * 66)
+    print("Full-batch second-pass penalty (updated from PR #50):")
+    bp_ratio   = bp_cost['backward'] / bp_cost['forward']
+    rbm1_ratio = rbm1_cost['negative'] / rbm1_cost['positive']
+    print(f"  Backprop  backward/forward    : {bp_ratio:.2f}x  "
+          f"(was 1.27x single-pattern)")
+    print(f"  Boltzmann CD-1 neg/pos        : {rbm1_ratio:.2f}x  "
+          f"(was 2.11x, single-pattern, encoder-3-parity)")
+    print()
+    print("Note: the 88 forward activations (8 patterns x 11 values each)")
+    print("now sit between W2 and the backward pass, increasing the penalty.")
+
+
+if __name__ == "__main__":
+    main()

--- a/v2-bytedmd/validate_implementations.py
+++ b/v2-bytedmd/validate_implementations.py
@@ -1,0 +1,153 @@
+"""
+Validates that the pure-Python kernels in encoder_pair_comparison.py produce
+identical outputs to the original numpy stubs.
+
+Checks:
+  backprop-8-3-8 : forward h, y and gradients dW1, dW2, db1, db2
+  encoder-3-parity: h_prob_pos, v_prob_neg, h_prob_neg (deterministic parts of CD)
+
+Run from the repo root:
+    python3 v2-bytedmd/validate_implementations.py
+"""
+
+import sys
+import math
+import random
+import numpy as np
+from pathlib import Path
+
+# --- import original numpy stubs ---
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "encoder-backprop-8-3-8"))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "encoder-3-parity"))
+
+import encoder_backprop_8_3_8 as bp_ref
+import encoder_3_parity as rbm_ref
+
+# --- import pure-Python kernels under test ---
+sys.path.insert(0, str(Path(__file__).parent))
+import encoder_pair_comparison as impl
+
+ATOL = 1e-6
+
+
+def arrays_close(a_py, b_np, name):
+    a = np.array(a_py, dtype=np.float64)
+    b = np.array(b_np, dtype=np.float64)
+    ok = np.allclose(a, b, atol=ATOL)
+    status = "OK" if ok else "FAIL"
+    maxdiff = float(np.max(np.abs(a - b)))
+    print(f"  {status}  {name}  (max_diff={maxdiff:.2e})")
+    return ok
+
+
+# ---------------------------------------------------------------------------
+# Validate backprop 8-3-8
+# ---------------------------------------------------------------------------
+
+def validate_backprop(seed=42):
+    print("=== backprop-8-3-8 ===")
+    rng = random.Random(seed)
+    W1_py = [[rng.uniform(-0.5, 0.5) for _ in range(3)] for _ in range(8)]
+    b1_py = [rng.uniform(-0.1, 0.1) for _ in range(3)]
+    W2_py = [[rng.uniform(-0.5, 0.5) for _ in range(8)] for _ in range(3)]
+    b2_py = [rng.uniform(-0.1, 0.1) for _ in range(8)]
+
+    # Convert to numpy for the reference model
+    model = bp_ref.EncoderMLP(seed=0)
+    model.W1 = np.array(W1_py, dtype=np.float64)
+    model.b1 = np.array(b1_py, dtype=np.float64)
+    model.W2 = np.array(W2_py, dtype=np.float64)
+    model.b2 = np.array(b2_py, dtype=np.float64)
+
+    data = bp_ref.make_encoder_data()   # 8x8 identity
+    x_np = data[0:1]                    # pattern 0, shape (1, 8)
+    x_py = list(x_np[0])
+
+    # --- forward ---
+    h_np, y_np = model.forward(x_np)   # shapes (1,3), (1,8)
+
+    h_py, y_py = impl._bp_forward(W1_py, b1_py, W2_py, b2_py, x_py)
+
+    ok = True
+    ok &= arrays_close(h_py, h_np[0], "forward h")
+    ok &= arrays_close(y_py, y_np[0], "forward y")
+
+    # --- gradients ---
+    target_py = x_py[:]
+    dW1_np, db1_np, dW2_np, db2_np = model.grads(x_np, x_np)
+
+    # Run full_step to get pure-Python gradients
+    result = impl.bp_full_step(W1_py, b1_py, W2_py, b2_py, x_py, target_py)
+    dW1_py, db1_py, dW2_py, db2_py = result
+
+    ok &= arrays_close(dW1_py, dW1_np, "dW1")
+    ok &= arrays_close(db1_py, db1_np, "db1")
+    ok &= arrays_close(dW2_py, dW2_np, "dW2")
+    ok &= arrays_close(db2_py, db2_np, "db2")
+
+    return ok
+
+
+# ---------------------------------------------------------------------------
+# Validate encoder-3-parity (RBM)
+# ---------------------------------------------------------------------------
+
+def validate_rbm(seed=42):
+    print("=== encoder-3-parity (RBM) ===")
+    rng = random.Random(seed)
+    W_py  = [[rng.gauss(0, 0.1) for _ in range(4)] for _ in range(3)]
+    b_v_py = [rng.uniform(-0.1, 0.1) for _ in range(3)]
+    b_h_py = [rng.uniform(-0.1, 0.1) for _ in range(4)]
+
+    # Build reference model
+    model = rbm_ref.ParityRBM(n_hidden=4, seed=0)
+    model.W   = np.array(W_py,   dtype=np.float32)
+    model.b_v = np.array(b_v_py, dtype=np.float32)
+    model.b_h = np.array(b_h_py, dtype=np.float32)
+
+    v_py = [0.0, 1.0, 1.0]   # even-parity pattern 011
+    v_np = np.array([v_py], dtype=np.float32)  # shape (1, 3)
+
+    # --- positive phase: h_prob_pos ---
+    h_prob_pos_np = model.hidden_prob(v_np)   # shape (1, 4)
+    h_prob_pos_py = impl._rbm_h_given_v(W_py, b_h_py, v_py)
+
+    ok = arrays_close(h_prob_pos_py, h_prob_pos_np[0], "h_prob_pos")
+
+    # --- negative phase: v_prob_neg (given fixed h_pos) ---
+    # Use a fixed binary h_pos so the comparison is deterministic
+    h_pos_py = [1.0, 0.0, 1.0, 0.0]
+    h_pos_np = np.array([h_pos_py], dtype=np.float32)
+
+    v_prob_neg_np = model.visible_prob(h_pos_np)   # shape (1, 3)
+    v_prob_neg_py = impl._rbm_v_given_h(W_py, b_v_py, h_pos_py)
+
+    ok &= arrays_close(v_prob_neg_py, v_prob_neg_np[0], "v_prob_neg")
+
+    # --- negative h: h_prob_neg (given fixed v_neg) ---
+    v_neg_py = [1.0, 0.0, 0.0]
+    v_neg_np = np.array([v_neg_py], dtype=np.float32)
+
+    h_prob_neg_np = model.hidden_prob(v_neg_np)
+    h_prob_neg_py = impl._rbm_h_given_v(W_py, b_h_py, v_neg_py)
+
+    ok &= arrays_close(h_prob_neg_py, h_prob_neg_np[0], "h_prob_neg")
+
+    return ok
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    results = []
+    results.append(validate_backprop())
+    print()
+    results.append(validate_rbm())
+    print()
+    if all(results):
+        print("All checks passed.")
+    else:
+        print("VALIDATION FAILED — pure-Python kernels do not match numpy stubs.")
+        sys.exit(1)


### PR DESCRIPTION
Contributes to #45 (v2 ByteDMD instrumentation). First algorithm pair: backprop vs Boltzmann CD on the encoder problem.

## What this adds

`v2-bytedmd/encoder_pair_comparison.py` — pure-Python implementations of one training step for each algorithm, instrumented with ByteDMD to measure second-pass weight-read penalty. Also includes `validate_implementations.py` which cross-checks every kernel against the original numpy stubs.

`bytedmd.py` is vendored from [cybertronai/ByteDMD](https://github.com/cybertronai/ByteDMD) (not yet on PyPI).

## Methodology

ByteDMD only traces Python-level operations, so numpy stubs can't be wrapped directly. The kernels here are pure Python (nested lists, no numpy). Validation confirms they match the numpy stubs:
- backprop forward/backward: max diff < 1e-15
- RBM probability computations: max diff < 4e-8 (float32 vs float64 from original)

The second-pass penalty is measured by decomposing the full step cost:
- `forward_cost = bytedmd(forward_phase, same_args_as_full_step)`
- `second_pass_cost = bytedmd(full_step, args) - forward_cost`

Both measurements use identical argument signatures so LRU stack depths are consistent.

## Results (single pattern, 5 random weight seeds)

```
Backprop 8-3-8  (48 weight values)
  forward  (reads W1 once, W2 once)         :     541
  backward (re-reads W2 once for delta_h)   :     685
  total                                      :   1,226
  cost/weight                                :    25.5
  second-pass penalty (bwd/fwd)             :    1.27x

Boltzmann CD-1  (12 weight values)
  positive phase (reads W once)             :     142
  negative phase (reads W twice more)       :     299
  total                                      :     441
  cost/weight                                :    36.8
  second-pass penalty (neg/pos)             :    2.11x
```

## Finding

Backprop has the **lower** second-pass penalty (1.27x vs 2.11x) — counter to the naive "backprop refetches all activations" framing.

Structural reason: in the backward pass, **W1 is never re-read**. `dW1 = x · delta_h` only needs `x` and `delta_h`, both recently created (shallow on the LRU stack). Only W2 is re-read once, displaced by 11 forward activations (h=3, y=8).

Boltzmann CD reads its smaller W matrix **three times** (positive phase + two reads in negative phase). The ~8 intermediate values from the positive phase (h_prob_pos=4, comparison results=4) represent ~67% relative displacement of W=12 values, vs ~23% for backprop's W2=24 values.

The "commute" penalty scales with the ratio of intermediate activations to weight matrix size, not simply whether weights are re-read.

## Running

```bash
cd v2-bytedmd
python3 validate_implementations.py   # confirm kernels match numpy stubs
python3 encoder_pair_comparison.py    # ByteDMD cost comparison
```

## Next pairs

Per #45, the natural follow-ups are `bars` vs `bars-rbm` and `shifter` vs `helmholtz-shifter`. The `encoder-4-2-4` (Boltzmann) would also close the size gap between these two encoders.