### PR TITLE
dev: add Nix dev shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,23 @@ The next step ([#45 v2](https://github.com/cybertronai/hinton-problems/issues/45
 
 Pure numpy + matplotlib throughout. Every stub runs on a laptop CPU. Each problem lives in its own folder with `<slug>.py` (model + train + eval), `README.md`, `make_<slug>_gif.py`, `visualize_<slug>.py`, an animated `<slug>.gif`, and a `viz/` folder of training curves and weight visualizations.
 
+## Development
+
+This repository includes a minimal Nix development shell with Python and
+NumPy:
+
+```bash
+nix develop
+python v2-bytedmd/validate_implementations.py
+python v2-bytedmd/total_cost_comparison.py
+```
+
+Or run one command directly:
+
+```bash
+nix develop -c python v2-bytedmd/validate_implementations.py
+```
+
 ## Visual tour
 
 | ![encoder-4-2-4](encoder-4-2-4/encoder.gif) | ![spline-images-factorial-vq](spline-images-factorial-vq/spline_images_factorial_vq.gif) |

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1777954456,
+        "narHash": "sha256-hGdgeU2Nk87RAuZyYjyDjFL6LK7dAZN5RE9+hrDTkDU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,33 @@
+{
+  description = "Development shell for hinton-problems";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs = { nixpkgs, ... }:
+    let
+      systems = [
+        "aarch64-darwin"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "x86_64-linux"
+      ];
+
+      forAllSystems = nixpkgs.lib.genAttrs systems;
+    in
+    {
+      devShells = forAllSystems (system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+          python = pkgs.python3.withPackages (ps: [
+            ps.numpy
+          ]);
+        in
+        {
+          default = pkgs.mkShell {
+            packages = [
+              python
+            ];
+          };
+        });
+    };
+}

--- a/v2-bytedmd/README.md
+++ b/v2-bytedmd/README.md
@@ -8,6 +8,13 @@ Because ByteDMD traces Python-level operations, all kernels here are pure Python
 
 ## Encoder pair — backprop vs Boltzmann
 
+Use the repo dev shell for scripts that import the NumPy reference stubs:
+
+```bash
+nix develop -c python v2-bytedmd/validate_implementations.py
+nix develop -c python v2-bytedmd/total_cost_comparison.py
+```
+
 `encoder_pair_comparison.py` — compares one training step of `encoder-backprop-8-3-8` (MLP + SGD) against `encoder-3-parity` (RBM + CD-1). Both architectures solve the encoder bottleneck; the question is which pays less to move weights through the memory hierarchy.
 
 ### Results (single pattern, 5 random weight seeds)


### PR DESCRIPTION
Adds a minimal Nix dev shell so the NumPy-based Hinton scripts run reproducibly on NixOS and other Nix-enabled machines.

The immediate motivation is the v2 ByteDMD work: `validate_implementations.py` and `total_cost_comparison.py` import the NumPy reference stubs, while bare `python3` may not have NumPy available.

## Changes

- Add `flake.nix` with a default dev shell containing Python + NumPy.
- Add `flake.lock`.
- Document `nix develop` usage in the top-level README.
- Add v2 ByteDMD run commands using `nix develop -c`.

## Test plan

- [x] `nix flake check`
- [x] `nix develop -c python -c 'import sys, numpy; print(sys.version.split()[0]); print(numpy.__version__)'`
- [x] `nix develop -c python v2-bytedmd/validate_implementations.py`
