### PR TITLE
docs(site): include DBN in mdBook counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ A reproducible-baseline catalog of the synthetic learning problems that appear i
 >
 > — Yaroslav, [issue #1](https://github.com/cybertronai/hinton-problems/issues/1#issuecomment-4363088986) (Sutro Group)
 
-This repository **is that baseline**. v1 ships 53 implementations covering the lineage from the 4-2-4 encoder (1985) through the shifter (1986), bars (1995), MultiMNIST (2017), Constellations (2019), Ellipse World (2022), and the Forward-Forward suite (2022). Each stub is a self-contained folder with model + train + eval + visualization + animated GIF, all in numpy, all runnable in <5 min per seed on an M-series laptop.
+This repository **is that baseline**. v1 shipped 53 implemented stubs covering the lineage from the shifter (1986), bars (1995), MultiMNIST (2017), Constellations (2019), Ellipse World (2022), and the Forward-Forward suite (2022). The current catalog has 54 implemented stubs: those 53 v1 stubs plus the DBN add-on. The site also keeps the pre-existing 4-2-4 encoder worked example as a problem chapter. Each stub is a self-contained folder with model + train + eval + visualization + animated GIF, all in numpy, all runnable in <5 min per seed on an M-series laptop.
 
-The next step ([#45 v2](https://github.com/cybertronai/hinton-problems/issues/45)) instruments these 53 baselines with [ByteDMD](https://github.com/cybertronai/ByteDMD) — Yaroslav's data-movement cost tracer — to measure the actual "commute" each algorithm pays.
+The next step ([#45 v2](https://github.com/cybertronai/hinton-problems/issues/45)) instruments the v1 baselines with [ByteDMD](https://github.com/cybertronai/ByteDMD) — Yaroslav's data-movement cost tracer — to measure the actual "commute" each algorithm pays.
 
 ## What's here
 
@@ -49,11 +49,11 @@ nix develop -c python v2-bytedmd/validate_implementations.py
 | ![ellipse-world](ellipse-world/ellipse_world.gif) | ![ff-recurrent-mnist](ff-recurrent-mnist/ff_recurrent_mnist.gif) |
 | [`ellipse-world`](ellipse-world/) — Culp/Sabour/Hinton 2022, eGLOM islands form across iterations (5-class, 92.2%). | [`ff-recurrent-mnist`](ff-recurrent-mnist/) — Hinton 2022, top-down recurrent Forward-Forward. |
 
-For the long-form picture-first walk through **all 53 stubs** — every GIF, organized by year, with notes on what each visualization is meant to show — see [`VISUAL_TOUR.md`](VISUAL_TOUR.md).
+For the long-form picture-first walk through **all current problem chapters** — the 54 implemented stubs plus the worked example, organized by year, with notes on what each visualization is meant to show — see [`VISUAL_TOUR.md`](VISUAL_TOUR.md).
 
 ## Catalog
 
-Each table shows the v1 result per stub. Full per-stub metrics (compile-time, GIF size, headline numbers) are in [`RESULTS.md`](RESULTS.md).
+Each table shows the current result per problem: the worked example, 53 v1 stubs, and the DBN add-on. Full per-stub metrics (compile-time, GIF size, headline numbers) are in [`RESULTS.md`](RESULTS.md).
 
 **Reproduces?** legend: `yes` = matches paper qualitatively or quantitatively; `partial` = method works, paper number not fully reached (gap documented in stub README); `no` = paper claim does not replicate.
 
@@ -292,7 +292,7 @@ problem-folder/
 ## Roadmap
 
 - [**#45 v2: ByteDMD instrumentation**](https://github.com/cybertronai/hinton-problems/issues/45) — measure data-movement cost per stub on these baselines (the actual research goal)
-- [**#46 v1.5: paper-scale reruns**](https://github.com/cybertronai/hinton-problems/issues/46) — close the 25 partial reproductions on Modal/GPU
+- [**#46 v1.5: paper-scale reruns**](https://github.com/cybertronai/hinton-problems/issues/46) — close the 25 v1 partial reproductions on Modal/GPU
 - See `Open questions / next experiments` section in each stub README for stub-specific follow-ups
 
 ## Contributing

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -1,6 +1,6 @@
-# RESULTS — v1 baselines
+# RESULTS — v1 baselines + DBN add-on
 
-Per-stub reproducibility, implementation difficulty, and run wallclock for the 53 implementations shipped across wave PRs #32–#41. Compiled from PR bodies for the v2 data-movement / ByteDMD filter.
+Per-stub reproducibility, implementation difficulty, and run wallclock for the current catalog: the pre-existing 4-2-4 worked example, 53 v1 implementations shipped across wave PRs #32–#41, and the DBN add-on. The summary statistics count the 54 implemented stubs; the worked example remains listed for continuity. Compiled from PR bodies for the v2 data-movement / ByteDMD filter.
 
 **Reproduces? legend**: `yes` = matches paper qualitatively or quantitatively; `partial` = method works, paper number not fully reached (gap documented in stub README); `no` = paper claim does not replicate (gap analysis documented).
 
@@ -235,10 +235,10 @@ Per-stub reproducibility, implementation difficulty, and run wallclock for the 5
 | Verdict | Count | Notes |
 |---|---:|---|
 | **yes** (full or qualitative match) | 27 | including all backprop foundations + most encoders + distillation-omitted-3 + ellipse-world + spline-VQ |
-| **partial** (method works, paper number gap documented) | 25 | mostly Forward-Forward at smaller scale, capsules at smaller arch, AIR variants without REINFORCE |
+| **partial** (method works, paper number gap documented) | 26 | mostly Forward-Forward at smaller scale, capsules at smaller arch, AIR variants without REINFORCE, plus the DBN add-on without up-down fine-tuning |
 | **no** (paper claim does NOT replicate) | 1 | affnist (gap wrong sign — three causes documented) |
 
-**Total: 53 stubs implemented, all in pure numpy, all <5 min/seed on a laptop except where noted.**
+**Total: 54 implemented stubs: 53 v1 stubs plus the DBN add-on, all in pure numpy, all <5 min/seed on a laptop except where noted.** The table also includes the pre-existing 4-2-4 worked example.
 
 ## v2 filter recommendation
 

--- a/VISUAL_TOUR.md
+++ b/VISUAL_TOUR.md
@@ -1,9 +1,10 @@
 # Visual tour
 
-A picture-first walk through all 53 v1 implementations. The
-[README](README.md) has a 4-GIF teaser and the result tables; this page is
-the long form — every stub, in catalog order, with its training animation
-and a short note on what the visualization is meant to show.
+A picture-first walk through all current problem chapters: the 54 implemented
+stubs plus the pre-existing 4-2-4 worked example. The [README](README.md)
+has a 4-GIF teaser and the result tables; this page is the long form —
+every chapter, in catalog order, with its training animation and a short
+note on what the visualization is meant to show.
 
 For per-stub metrics (compile time, GIF size, headline numbers) see
 [`RESULTS.md`](RESULTS.md). For the experimental design of any single
@@ -801,7 +802,7 @@ listed there; rerunning with the same seeds reproduces them bit-for-bit.
   paper-vs-implemented headline metric in one table.
 - **For the research goal these baselines exist for**: [issue #45 (v2,
   ByteDMD instrumentation)](https://github.com/cybertronai/hinton-problems/issues/45) —
-  these 53 implementations are the substrate the data-movement cost
-  tracer will run against.
+  the v1 implementations are the substrate the data-movement cost tracer
+  will run against.
 - **For paper-scale reruns**: [issue #46 (v1.5)](https://github.com/cybertronai/hinton-problems/issues/46) —
-  closing the 25 partial reproductions on Modal/GPU.
+  closing the 25 v1 partial reproductions on Modal/GPU.

--- a/bin/build_book.py
+++ b/bin/build_book.py
@@ -8,10 +8,9 @@ mdBook requires:
 
 This script:
 1. Resets src/
-2. Copies README.md -> src/index.md
-3. Copies RESULTS.md -> src/results.md
-4. Copies each stub folder -> src/<slug>/ (READMEs + viz/ + .gif)
-5. Generates src/SUMMARY.md grouped by decade
+2. Copies top-level docs into src/
+3. Copies each stub folder -> src/<slug>/ (READMEs + viz/ + .gif)
+4. Generates src/SUMMARY.md grouped by decade
 
 Usage:
     python3 bin/build_book.py
@@ -69,6 +68,7 @@ DECADES = [
     ]),
     ("2000s — RBMs & deep belief", [
         "bars-rbm",
+        "dbn-mnist",
         "transforming-pairs",
         "bouncing-balls-2",
         "bouncing-balls-3",
@@ -155,7 +155,7 @@ def main() -> None:
     (SRC / "SUMMARY.md").write_text("\n".join(summary) + "\n")
 
     n_chapters = len(all_stubs) - len(missing)
-    print(f"Built {SRC} with {n_chapters} stub chapters + 2 top-level pages")
+    print(f"Built {SRC} with {n_chapters} problem chapters + 4 top-level pages")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add dbn-mnist to the mdBook generator's 2000s chapter list
- clarify 53 v1 stubs + DBN add-on = 54 implemented stubs, with encoder-4-2-4 retained as the worked-example chapter
- update results and visual-tour count wording to match generated site output

## Verification
- git diff --check
- nix develop -c python bin/build_book.py
- inspected src/SUMMARY.md for dbn-mnist under 2000s
- nix run nixpkgs#mdbook -- build