### PR TITLE
docs(readme): mirror schmidhuber-problems bullet header format

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,14 @@
 
 A reproducible-baseline catalog of the synthetic learning problems that appear in Geoffrey Hinton's experimental papers from 1981 through 2022 — implemented in pure numpy, runnable on a laptop CPU, with paper-comparison metrics per stub.
 
-**Site**: https://cybertronai.github.io/hinton-problems/ • **Catalog**: [RESULTS.md](RESULTS.md) • **55 of 55 stubs implemented** (PRs #32–#41 + DBN + DBM add-ons)
-
-**Build cost / token math**: ~661M tokens across 63 sessions (lead + 62 subagent dispatches), 93.5% cache_read. The harness "~800k" was context-window utilisation, not cumulative consumption. Breakdown: [BUILD_NOTES.md § Token consumption](BUILD_NOTES.md) + [issue #56](https://github.com/cybertronai/hinton-problems/issues/56).
+- **GitHub**: https://github.com/cybertronai/hinton-problems
+- **Site**: https://cybertronai.github.io/hinton-problems/
+- **Catalog**: [RESULTS.md](RESULTS.md)
+- **Visual tour**: [VISUAL_TOUR.md](VISUAL_TOUR.md)
+- **Build notes**: [BUILD_NOTES.md](BUILD_NOTES.md)
+- **Status**: 55 of 55 stubs implemented (PRs #32–#41 + DBN + DBM add-ons)
+- **Build cost / token math**: ~661M tokens across 63 sessions (lead + 62 subagent dispatches), 93.5% cache_read. The harness "~800k" was context-window utilisation, not cumulative consumption. Breakdown: [BUILD_NOTES.md § Token consumption](BUILD_NOTES.md) + [issue #56](https://github.com/cybertronai/hinton-problems/issues/56).
+- **Companion**: [`schmidhuber-problems`](https://github.com/cybertronai/schmidhuber-problems) — algorithmic-lineage counterpart (58 stubs)
 
 ## Introduction
 


### PR DESCRIPTION
## What this PR does

Converts the README header from two single-line bullet-separated paragraphs into a clean bullet list, matching the [schmidhuber-problems README](https://github.com/cybertronai/schmidhuber-problems/blob/main/README.md) header layout exactly.

## Before

```
**Site**: https://cybertronai.github.io/hinton-problems/ • **Catalog**: [RESULTS.md](RESULTS.md) • **55 of 55 stubs implemented** (PRs #32–#41 + DBN + DBM add-ons)

**Build cost / token math**: ~661M tokens across 63 sessions (lead + 62 subagent dispatches), 93.5% cache_read. The harness "~800k" was context-window utilisation, not cumulative consumption. Breakdown: [BUILD_NOTES.md § Token consumption](BUILD_NOTES.md) + [issue #56](https://github.com/cybertronai/hinton-problems/issues/56).
```

## After

```
- **GitHub**: https://github.com/cybertronai/hinton-problems
- **Site**: https://cybertronai.github.io/hinton-problems/
- **Catalog**: [RESULTS.md](RESULTS.md)
- **Visual tour**: [VISUAL_TOUR.md](VISUAL_TOUR.md)
- **Build notes**: [BUILD_NOTES.md](BUILD_NOTES.md)
- **Status**: 55 of 55 stubs implemented (PRs #32–#41 + DBN + DBM add-ons)
- **Build cost / token math**: ~661M tokens across 63 sessions (lead + 62 subagent dispatches), 93.5% cache_read. The harness "~800k" was context-window utilisation, not cumulative consumption. Breakdown: [BUILD_NOTES.md § Token consumption](BUILD_NOTES.md) + [issue #56](https://github.com/cybertronai/hinton-problems/issues/56).
- **Companion**: [`schmidhuber-problems`](https://github.com/cybertronai/schmidhuber-problems) — algorithmic-lineage counterpart (58 stubs)
```

## What's new (vs simply reformatting)

Three pointers that existed elsewhere in the repo or README body but were not surfaced in the header bullets are now there:

- **GitHub** — explicit repo URL up top (like schmidhuber-problems)
- **Visual tour** → `VISUAL_TOUR.md`
- **Build notes** → `BUILD_NOTES.md`
- **Companion** — the schmidhuber-problems pair link that previously only appeared deep in the README body

## Body content unchanged

Only the header block above the `## Introduction` heading. All catalog tables, citations, year groupings, and the `Roadmap` / `Contributing` / `License` sections are untouched.

---

_agent-0bserver07 (Claude Code) on behalf of Yad_