### PR TITLE
v2: validate total-cost kernels

### DIFF
--- a/v2-bytedmd/validate_implementations.py
+++ b/v2-bytedmd/validate_implementations.py
@@ -1,10 +1,13 @@
 """
-Validates that the pure-Python kernels in encoder_pair_comparison.py produce
-identical outputs to the original numpy stubs.
+Validates that the pure-Python kernels used by the v2 ByteDMD scripts match
+the original numpy stubs.
 
 Checks:
   backprop-8-3-8 : forward h, y and gradients dW1, dW2, db1, db2
   encoder-3-parity: h_prob_pos, v_prob_neg, h_prob_neg (deterministic parts of CD)
+  total_cost_comparison:
+    - backprop-8-3-8 full-batch forward + gradients
+    - encoder-8-3-8 full-batch positive phase + deterministic CD gradients
 
 Run from the repo root:
     python3 v2-bytedmd/validate_implementations.py
@@ -19,13 +22,16 @@ from pathlib import Path
 # --- import original numpy stubs ---
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "encoder-backprop-8-3-8"))
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "encoder-3-parity"))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "encoder-8-3-8"))
 
 import encoder_backprop_8_3_8 as bp_ref
 import encoder_3_parity as rbm_ref
+import encoder_8_3_8 as rbm8_ref
 
 # --- import pure-Python kernels under test ---
 sys.path.insert(0, str(Path(__file__).parent))
 import encoder_pair_comparison as impl
+import total_cost_comparison as total_impl
 
 ATOL = 1e-6
 
@@ -137,6 +143,106 @@ def validate_rbm(seed=42):
 
 
 # ---------------------------------------------------------------------------
+# Validate total_cost_comparison.py full-batch kernels
+# ---------------------------------------------------------------------------
+
+def validate_total_cost_backprop(seed=123):
+    print("=== total_cost_comparison backprop full-batch ===")
+    rng = random.Random(seed)
+    W1_py = [[rng.uniform(-0.5, 0.5) for _ in range(3)] for _ in range(8)]
+    b1_py = [rng.uniform(-0.1, 0.1) for _ in range(3)]
+    W2_py = [[rng.uniform(-0.5, 0.5) for _ in range(8)] for _ in range(3)]
+    b2_py = [rng.uniform(-0.1, 0.1) for _ in range(8)]
+
+    model = bp_ref.EncoderMLP(seed=0)
+    model.W1 = np.array(W1_py, dtype=np.float64)
+    model.b1 = np.array(b1_py, dtype=np.float64)
+    model.W2 = np.array(W2_py, dtype=np.float64)
+    model.b2 = np.array(b2_py, dtype=np.float64)
+
+    data_np = bp_ref.make_encoder_data()
+    patterns_py = data_np.astype(float).tolist()
+
+    hs_py, ys_py = total_impl.bp_fullbatch_forward(
+        W1_py, b1_py, W2_py, b2_py, patterns_py)
+    hs_np, ys_np = model.forward(data_np)
+
+    ok = True
+    ok &= arrays_close(hs_py, hs_np, "full-batch forward h")
+    ok &= arrays_close(ys_py, ys_np, "full-batch forward y")
+
+    dW1_py, db1_py, dW2_py, db2_py = total_impl.bp_fullbatch_step(
+        W1_py, b1_py, W2_py, b2_py, patterns_py)
+    dW1_np, db1_np, dW2_np, db2_np = model.grads(data_np, data_np)
+
+    # EncoderMLP.grads returns mean full-batch gradients; the traced kernel
+    # accumulates the equivalent batch-sum gradients. The access pattern is the
+    # same, so validate against the mean gradients scaled by batch size.
+    batch_n = data_np.shape[0]
+    ok &= arrays_close(dW1_py, dW1_np * batch_n, "full-batch dW1 sum")
+    ok &= arrays_close(db1_py, db1_np * batch_n, "full-batch db1 sum")
+    ok &= arrays_close(dW2_py, dW2_np * batch_n, "full-batch dW2 sum")
+    ok &= arrays_close(db2_py, db2_np * batch_n, "full-batch db2 sum")
+
+    return ok
+
+
+def _threshold_sample(probs):
+    return [1.0 if p >= 0.5 else 0.0 for p in probs]
+
+
+def validate_total_cost_rbm(seed=123, k=2):
+    print("=== total_cost_comparison encoder-8-3-8 full-batch RBM ===")
+    rng = random.Random(seed)
+    W_py = [[rng.gauss(0, 0.1) for _ in range(3)] for _ in range(16)]
+    b_v_py = [rng.uniform(-0.1, 0.1) for _ in range(16)]
+    b_h_py = [rng.uniform(-0.1, 0.1) for _ in range(3)]
+
+    model = rbm8_ref.EncoderRBM(seed=0)
+    model.W = np.array(W_py, dtype=np.float32)
+    model.b_v = np.array(b_v_py, dtype=np.float32)
+    model.b_h = np.array(b_h_py, dtype=np.float32)
+
+    data_np = rbm8_ref.make_encoder_data().astype(np.float32)
+    patterns_py = data_np.astype(float).tolist()
+
+    h_probs_pos_py = total_impl.rbm_fullbatch_positive(
+        W_py, b_v_py, b_h_py, patterns_py, k=k)
+    h_probs_pos_np = model.hidden_prob(data_np)
+
+    ok = arrays_close(h_probs_pos_py, h_probs_pos_np, "full-batch h_prob_pos")
+
+    old_sample = total_impl._sample
+    total_impl._sample = _threshold_sample
+    try:
+        dW_py, db_v_py, db_h_py = total_impl.rbm_fullbatch_step(
+            W_py, b_v_py, b_h_py, patterns_py, k=k)
+    finally:
+        total_impl._sample = old_sample
+
+    h_samples_np = (h_probs_pos_np >= 0.5).astype(np.float32)
+    v_negs_np = data_np.copy()
+    h_negs_np = h_samples_np
+    h_probs_neg_np = h_probs_pos_np
+    for _ in range(k):
+        v_probs_neg_np = model.visible_prob(h_negs_np)
+        v_negs_np = (v_probs_neg_np >= 0.5).astype(np.float32)
+        h_probs_neg_np = model.hidden_prob(v_negs_np)
+        h_negs_np = (h_probs_neg_np >= 0.5).astype(np.float32)
+
+    batch_n = data_np.shape[0]
+    dW_np = (data_np.T @ h_probs_pos_np - v_negs_np.T @ h_probs_neg_np) / batch_n
+    db_v_np = (data_np - v_negs_np).mean(axis=0)
+    db_h_np = (h_probs_pos_np - h_probs_neg_np).mean(axis=0)
+
+    ok &= arrays_close(dW_py, dW_np, "full-batch dW CD-k")
+    ok &= arrays_close(db_v_py, db_v_np, "full-batch db_v CD-k")
+    ok &= arrays_close(db_h_py, db_h_np, "full-batch db_h CD-k")
+
+    return ok
+
+
+# ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 
@@ -145,6 +251,10 @@ if __name__ == "__main__":
     results.append(validate_backprop())
     print()
     results.append(validate_rbm())
+    print()
+    results.append(validate_total_cost_backprop())
+    print()
+    results.append(validate_total_cost_rbm())
     print()
     if all(results):
         print("All checks passed.")


### PR DESCRIPTION
## Summary
- validate total_cost_comparison backprop full-batch forward and batch-sum gradients against the NumPy 8-3-8 MLP reference
- validate total_cost_comparison encoder-8-3-8 RBM positive phase and deterministic CD-k gradients against the NumPy RBM reference
- keep the slice scoped to validation hardening for the existing v2 measurement contract

## Tests
- git diff --check
- nix flake check
- nix develop -c python v2-bytedmd/validate_implementations.py